### PR TITLE
changing behavior for rows with too few columns

### DIFF
--- a/csvql.gemspec
+++ b/csvql.gemspec
@@ -21,5 +21,7 @@ Gem::Specification.new do |spec|
   # spec.add_development_dependency "bundler", "~> 1.6"
   # spec.add_development_dependency "rake"
   # spec.add_development_dependency "rspec"
+  # spec.add_development_dependency "pry"
+  # spec.add_development_dependency "minitest"
   spec.add_runtime_dependency "sqlite3"
 end

--- a/lib/csvql.rb
+++ b/lib/csvql.rb
@@ -84,9 +84,10 @@ module Csvql
                    else
                      cols.size.times.map {|i| "c#{i}" }
                    end
-        schema = col_name.map {|c| "#{c} NONE" }.join(",")
+        schema = col_name.map {|c| "[#{c}] NONE" }.join(",")
       end
       csvfile.rewind unless opt.header
+
 
       tbl = TableHandler.new(opt.save_to, opt.console)
       tbl.drop_table(opt.table_name) unless opt.append

--- a/lib/csvql/csvql.rb
+++ b/lib/csvql/csvql.rb
@@ -18,7 +18,7 @@ module Csvql
     end
 
     def create_table(schema, table_name="tbl")
-      @col_name = schema.split(",").map {|c| c.split.first.strip }
+      @col_name = schema.split(",").map {|c| c.match(/\[.*\]/).to_s }
       @col_size = @col_name.size
       @table_name = table_name
       exec "CREATE TABLE IF NOT EXISTS #{@table_name} (#{schema})"

--- a/lib/csvql/csvql.rb
+++ b/lib/csvql/csvql.rb
@@ -40,9 +40,11 @@ module Csvql
     end
 
     def insert(cols, line)
-      if cols.size != @col_size
-        puts "line #{line}: wrong number of fields in line (skipping)"
+      if cols.size > @col_size
+        puts "line #{line}: too many fields in line (skipping)"
         return
+      elsif cols.size < @col_size
+        cols << Array.new(@col_size - cols.size)
       end
       @pre ||= prepare(cols)
       @pre.execute(cols)

--- a/test/header_test.csv
+++ b/test/header_test.csv
@@ -1,0 +1,1 @@
+select,from,table,header with spaces

--- a/test/table_creation.rb
+++ b/test/table_creation.rb
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+
+require 'minitest/autorun'
+require 'tempfile'
+require 'sqlite3'
+#require 'pry'
+
+begin
+  load '../lib/csvql.rb'
+rescue LoadError
+  abort("please change directory to test/; QUITTING")
+end
+
+class TestTableCreation < MiniTest::Test
+  def setup
+  end
+
+  #you should not have to update this method to add new test columns to header_test.csv
+  def test_parse_headers
+    tmpdbfile = Tempfile.new('tmp.db')
+    args = ["--header", 
+            "--source", "header_test.csv", 
+            "--save-to", tmpdbfile.path, 
+            "--ifs=" ",",
+            "--table-name","header_test"]
+    Csvql.run(args)
+
+    db = SQLite3::Database.new tmpdbfile.path
+    headers_from_db = db.execute2('select * from header_test;')[0]
+    headers_from_file = File.open('header_test.csv').each_line.first.gsub(/\n/,'').split(',')
+
+    #binding.pry
+    assert_equal headers_from_db, headers_from_file
+  end
+end


### PR DESCRIPTION
Current behavior is to not insert rows if the number of columns in line
does not match number of columns in header.  Changing this to exclude
rows only if the number of columns in line is greater than number in
header.  For lines with less columns than header, will pad the end of
the line with enough Nils to make number of columns equal.

Reason for this is that some CSV files do not have commas at the end
of the file for null values and I want to insert these rows anyways,
instead of rejecting them.